### PR TITLE
Find / discover existing BibData RXL file

### DIFF
--- a/lib/relaton/bibdata.rb
+++ b/lib/relaton/bibdata.rb
@@ -27,6 +27,7 @@ module Relaton
       script
       edition
       datetype
+      bib_rxl
     ]
 
     attr_accessor *ATTRIBS

--- a/lib/relaton/cli/relaton_file.rb
+++ b/lib/relaton/cli/relaton_file.rb
@@ -139,7 +139,15 @@ module Relaton
 
         relaton_collection.items.each do |content|
           name = build_filename(nil, content.docidentifier)
+          find_available_bibrxl_file(name, output_dir, content)
           write_to_file(content.send(output_type), output_dir, name)
+        end
+      end
+
+      def find_available_bibrxl_file(name, ouputdir, content)
+        if options[:extension] == "yaml" || options[:extension] == "yml"
+          bib_rxl = Pathname.new([outdir, name].join("/")).sub_ext(".rxl")
+          content.bib_rxl = bib_rxl.to_s if File.file?(bib_rxl)
         end
       end
 


### PR DESCRIPTION
Currently, the registry generations (eg: Calconnect) depends on the rxl field value to represents the relaton xml file.The way we handle is to split the existing files, then concatenate it and then split it
again, this way it would fix the relaton xml link.

But now that we have optimized that process by the split interface, and we still need a way to fix those broken link, so this commit will look for that and if available in output directory then link those as a `bib_rxl`, and everything will work same as before.

Related: #40 